### PR TITLE
add user agent to client

### DIFF
--- a/fdk.go
+++ b/fdk.go
@@ -232,8 +232,9 @@ func FalconClient(ctx context.Context, r Request) (*client.CrowdStrikeAPISpecifi
 	}
 	cloud := falcon.Cloud(c)
 	return fcFactory(&falcon.ApiConfig{
-		AccessToken: token,
-		Cloud:       cloud,
-		Context:     ctx,
+		AccessToken:       token,
+		Cloud:             cloud,
+		Context:           ctx,
+		UserAgentOverride: fmt.Sprintf("foundry-fn/%s", Version),
 	})
 }

--- a/fdk_test.go
+++ b/fdk_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -177,10 +178,12 @@ func base64Encode(t *testing.T, v string) string {
 func TestFalconClient(t *testing.T) {
 	var accessToken string
 	var cloud falcon.CloudType
+	var userAgent string
 
 	factory := func(cfg *falcon.ApiConfig) (*client.CrowdStrikeAPISpecification, error) {
 		accessToken = cfg.AccessToken
 		cloud = cfg.Cloud
+		userAgent = cfg.UserAgentOverride
 		return &client.CrowdStrikeAPISpecification{}, nil
 	}
 
@@ -234,6 +237,7 @@ func TestFalconClient(t *testing.T) {
 				assert.NotNil(t, c)
 				assert.Equal(t, "abc", accessToken)
 				assert.Equal(t, falcon.CloudType(falcon.CloudUs2), cloud)
+				assert.Equal(t, fmt.Sprintf("foundry-fn/%s", Version), userAgent)
 			},
 		},
 		{
@@ -257,6 +261,7 @@ func TestFalconClient(t *testing.T) {
 				assert.NotNil(t, c)
 				assert.Equal(t, "abc", accessToken)
 				assert.Equal(t, falcon.CloudType(falcon.CloudUs1), cloud)
+				assert.Equal(t, fmt.Sprintf("foundry-fn/%s", Version), userAgent)
 			},
 		},
 	}

--- a/version.go
+++ b/version.go
@@ -1,0 +1,4 @@
+package fdk
+
+// Version is the current foundry-fn's version.
+const Version = "0.1.0"

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package fdk
 
 // Version is the current foundry-fn's version.
-const Version = "0.1.0"
+const Version = "0.2.0"


### PR DESCRIPTION
This pr adds a user agent to the goFalcon client so we can track usage from foundry apps. Example:

<img width="903" alt="image" src="https://github.com/CrowdStrike/foundry-fn-go/assets/35144141/746b83ae-2478-4e49-b953-93f32eea5d4e">
