### PR TITLE
Add log statement at server start.

### DIFF
--- a/fdk.go
+++ b/fdk.go
@@ -176,6 +176,7 @@ func listen(s *http.Server, shutdownTimeout time.Duration) {
 
 	// Run the HTTP server in a separate go-routine.
 	go func() {
+		log.Printf("Serving HTTP server to %s", s.Addr)
 		if err := s.ListenAndServe(); errors.Is(err, http.ErrServerClosed) {
 			log.Printf("[entrypoint] Error ListenAndServe: %v", err)
 			close(idleConnsClosed)


### PR DESCRIPTION
A quick PR that add log statement to notify on which port the server is running and if he is running.