### PR TITLE
fix: move logging to run calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ func (c config) OK() error {
    1. The `Response` contains fields `Body` (the payload of the response), `Code` (an HTTP status code),
       `Errors` (a slice of `APIError`s), and `Headers` (a map of any special HTTP headers which should be present on
       the response).
-      4`main()`: Initialization and bootstrap logic all contained with fdk.Run and handler constructor.
+4. `main()`: Initialization and bootstrap logic all contained with fdk.Run and handler constructor.
 
 more examples can be found at:
 * [fn with config](examples/fn_config) 

--- a/runner_http.go
+++ b/runner_http.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"time"
 )
 
 const (
@@ -58,8 +59,11 @@ func (r *runnerHTTP) Run(ctx context.Context, logger *slog.Logger, h Handler) {
 	go func() {
 		select {
 		case <-ctx.Done():
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+
 			logger.Info("shutting down HTTP server...")
-			if err := s.Shutdown(ctx); err != nil {
+			if err := s.Shutdown(shutdownCtx); err != nil {
 				logger.Error("failed to shutdown server", "err", err)
 			}
 		}


### PR DESCRIPTION
not all runtimes will produce logs when the runner hasn't been started. We consolidate our config logging to the runner as we're responding with an error.