### PR TITLE
fix: resetting local runner back to the nested variant of v0.3.0

### DIFF
--- a/runner_http.go
+++ b/runner_http.go
@@ -20,12 +20,6 @@ const (
 	mb = 1 << 20
 )
 
-const (
-	headerTraceID = "X-Cs-Traceid"
-	headerOrigin  = "X-Cs-Origin"
-	headerExecID  = "X-Cs-Executionid"
-)
-
 type runnerHTTP struct{}
 
 func (r *runnerHTTP) Run(ctx context.Context, logger *slog.Logger, h Handler) {
@@ -34,7 +28,7 @@ func (r *runnerHTTP) Run(ctx context.Context, logger *slog.Logger, h Handler) {
 		r, err := toRequest(req)
 		if err != nil {
 			logger.Error("failed to create request", "err", err)
-			writeErr := writeResponse(logger, req, w, Response{
+			writeErr := writeResponse(logger, w, Response{
 				Errors: []APIError{{Code: http.StatusInternalServerError, Message: "unable to process incoming request"}},
 			})
 			if writeErr != nil {
@@ -45,7 +39,7 @@ func (r *runnerHTTP) Run(ctx context.Context, logger *slog.Logger, h Handler) {
 
 		resp := h.Handle(ctx, r)
 
-		err = writeResponse(logger, req, w, resp)
+		err = writeResponse(logger, w, resp)
 		if err != nil {
 			logger.Error("failed to write response", "err", err)
 		}
@@ -76,82 +70,71 @@ func (r *runnerHTTP) Run(ctx context.Context, logger *slog.Logger, h Handler) {
 }
 
 func toRequest(req *http.Request) (Request, error) {
-	r := Request{
+	var r struct {
+		Body        json.RawMessage `json:"body"`
+		Context     json.RawMessage `json:"context"`
+		AccessToken string          `json:"access_token"`
+		Method      string          `json:"method"`
+		Params      struct {
+			Header http.Header `json:"header"`
+			Query  url.Values  `json:"query"`
+		} `json:"params"`
+		URL string `json:"url"`
+	}
+	payload, err := io.ReadAll(io.LimitReader(req.Body, 5*mb))
+	if err != nil {
+		return Request{}, fmt.Errorf("failed to read request body: %s", err)
+	}
+
+	if err = json.Unmarshal(payload, &r); err != nil {
+		return Request{}, fmt.Errorf("failed to unmarshal request body: %s", err)
+	}
+
+	// Ensure headers are canonically formatted else header.Get("my-key") won't necessarily work.
+	hCanon := make(http.Header)
+	for k, v := range r.Params.Header {
+		for _, s := range v {
+			hCanon.Add(k, s)
+		}
+	}
+	r.Params.Header = hCanon
+
+	out := Request{
+		Body:    r.Body,
+		Context: r.Context,
 		Params: struct {
 			Header http.Header
 			Query  url.Values
-		}{
-			Header: req.Header,
-			Query:  req.URL.Query(),
-		},
-		URL:    req.URL.Path,
-		Method: req.Method,
+		}{Header: r.Params.Header, Query: r.Params.Query},
+		URL:         r.URL,
+		Method:      r.Method,
+		AccessToken: r.AccessToken,
 	}
-	if req.Body != nil {
-		body, err := io.ReadAll(io.LimitReader(req.Body, 5*mb))
-		if err != nil {
-			return Request{}, err
-		}
-		if len(body) > 0 {
-			r.Body = body
-
-			var ctxPayload struct {
-				Context json.RawMessage `json:"context"`
-			}
-			_ = json.Unmarshal(body, &ctxPayload)
-			r.Context = ctxPayload.Context
-		}
-	}
-
-	return r, nil
+	return out, nil
 }
 
-func addReqHeaders(reqH, respH http.Header) http.Header {
-	if respH == nil {
-		respH = make(http.Header, 3)
-	}
-	takeHeaders(reqH, respH, headerExecID, headerOrigin, headerTraceID)
-	return respH
-}
-
-func takeHeaders(reqH, respH http.Header, headers ...string) {
-	for _, header := range headers {
-		if v := reqH.Get(header); v != "" {
-			respH.Set(header, v)
-		}
-	}
-}
-
-func writeResponse(logger *slog.Logger, req *http.Request, w http.ResponseWriter, resp Response) error {
-	for name, vals := range addReqHeaders(req.Header, resp.Header) {
-		for _, v := range vals {
-			w.Header().Set(name, v)
-		}
-	}
-
+func writeResponse(logger *slog.Logger, w http.ResponseWriter, resp Response) error {
 	b, err := json.Marshal(struct {
-		Errors []APIError     `json:"errors"`
-		Body   json.Marshaler `json:"body"`
+		Body    json.Marshaler `json:"body,omitempty"`
+		Code    int            `json:"code,omitempty"`
+		Errors  []APIError     `json:"errors"`
+		Headers http.Header    `json:"headers,omitempty"`
 	}{
-		Errors: resp.Errors,
-		Body:   resp.Body,
+		Body:    resp.Body,
+		Code:    resp.StatusCode(),
+		Errors:  resp.Errors,
+		Headers: resp.Header,
 	})
 	if err != nil {
 		logger.Error("failed to marshal json payload with body", "err", err)
-		b, err = json.Marshal(struct {
-			Errors []APIError `json:"errors"`
-		}{
-			Errors: append(resp.Errors, APIError{Code: http.StatusInternalServerError, Message: err.Error()}),
-		})
-		if err != nil {
-			logger.Error("failed to marshal json error payload", "err", err)
-		}
+	}
+	if len(b) == 0 {
+		return nil
 	}
 
-	if resp.StatusCode() > 0 {
-		w.WriteHeader(resp.StatusCode())
+	if code := resp.StatusCode(); code != 0 {
+		w.WriteHeader(code)
 	}
-
 	_, err = w.Write(b)
 	return err
 }

--- a/runner_test.go
+++ b/runner_test.go
@@ -5,12 +5,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"reflect"
 	"strconv"
@@ -25,15 +25,17 @@ func TestRun_httprunner(t *testing.T) {
 	t.Run("when executing provided handler with successful startup", func(t *testing.T) {
 		type (
 			inputs struct {
+				accessToken string
 				body        []byte
 				config      string
+				context     []byte
 				headers     http.Header
 				method      string
 				path        string
 				queryParams url.Values
 			}
 
-			wantFn func(t *testing.T, resp *http.Response)
+			wantFn func(t *testing.T, resp *http.Response, got respBody)
 		)
 
 		tests := []struct {
@@ -60,17 +62,9 @@ func TestRun_httprunner(t *testing.T) {
 					m.Delete("/path", newSimpleHandler(cfg))
 					return m
 				},
-				want: func(t *testing.T, resp *http.Response) {
+				want: func(t *testing.T, resp *http.Response, got respBody) {
 					equalVals(t, 201, resp.StatusCode)
-
-					wantHeaders := make(http.Header)
-					wantHeaders.Set("X-Cs-Origin", "fooorigin")
-					wantHeaders.Set("X-Cs-Executionid", "exec_id")
-					wantHeaders.Set("X-Cs-Traceid", "trace_id")
-					containsHeaders(t, wantHeaders, resp.Header)
-
-					var got respBody
-					decodeBody(t, resp.Body, &got)
+					equalVals(t, 201, got.Code)
 
 					if len(got.Errs) > 0 {
 						t.Errorf("received unexpected errors\n\t\tgot:\t%+v", got.Errs)
@@ -79,16 +73,15 @@ func TestRun_httprunner(t *testing.T) {
 					echo := got.Req
 					equalVals(t, config{Str: "val", Int: 1}, echo.Config)
 
-					if len(echo.Req.Body) > 0 {
-						t.Errorf("invalid request body received\n\t\tgot: %s", string(echo.Req.Body))
-					}
-					if len(echo.Req.Context) > 0 {
-						t.Errorf("invalid request context received\n\t\tgot: %s", string(echo.Req.Context))
-					}
 					equalVals(t, "/path", echo.Req.Path)
 					equalVals(t, "DELETE", echo.Req.Method)
-					containsHeaders(t, wantHeaders, echo.Req.Headers)
 					equalVals(t, "id1", echo.Req.Queries.Get("ids"))
+
+					wantHeaders := make(http.Header)
+					wantHeaders.Set("X-Cs-Origin", "fooorigin")
+					wantHeaders.Set("X-Cs-Executionid", "exec_id")
+					wantHeaders.Set("X-Cs-Traceid", "trace_id")
+					containsHeaders(t, wantHeaders, echo.Req.Headers)
 				},
 			},
 			{
@@ -109,17 +102,9 @@ func TestRun_httprunner(t *testing.T) {
 					m.Get("/path", newSimpleHandler(cfg))
 					return m
 				},
-				want: func(t *testing.T, resp *http.Response) {
+				want: func(t *testing.T, resp *http.Response, got respBody) {
 					equalVals(t, 201, resp.StatusCode)
-
-					wantHeaders := make(http.Header)
-					wantHeaders.Set("X-Cs-Origin", "fooorigin")
-					wantHeaders.Set("X-Cs-Executionid", "exec_id")
-					wantHeaders.Set("X-Cs-Traceid", "trace_id")
-					containsHeaders(t, wantHeaders, resp.Header)
-
-					var got respBody
-					decodeBody(t, resp.Body, &got)
+					equalVals(t, 201, got.Code)
 
 					if len(got.Errs) > 0 {
 						t.Errorf("received unexpected errors\n\t\tgot:\t%+v", got.Errs)
@@ -130,15 +115,21 @@ func TestRun_httprunner(t *testing.T) {
 
 					equalVals(t, "GET", echo.Req.Method)
 					equalVals(t, "/path", echo.Req.Path)
-					containsHeaders(t, wantHeaders, echo.Req.Headers)
 					equalVals(t, "baz", echo.Req.Queries.Get("bar"))
+
+					wantHeaders := make(http.Header)
+					wantHeaders.Set("X-Cs-Origin", "fooorigin")
+					wantHeaders.Set("X-Cs-Executionid", "exec_id")
+					wantHeaders.Set("X-Cs-Traceid", "trace_id")
+					containsHeaders(t, wantHeaders, echo.Req.Headers)
 				},
 			},
 			{
 				name: "simple POST request should pass",
 				inputs: inputs{
-					body:   []byte(`{"dodgers":"stink","context":{"kings":"stink_too"}}`),
-					config: `{"string": "val","integer": 1}`,
+					body:    []byte(`{"dodgers":"stink"}`),
+					context: []byte(`{"kings":"stink_too"}`),
+					config:  `{"string": "val","integer": 1}`,
 					headers: http.Header{
 						"X-Cs-Origin":      []string{"fooorigin"},
 						"X-Cs-Executionid": []string{"exec_id"},
@@ -152,17 +143,9 @@ func TestRun_httprunner(t *testing.T) {
 					m.Post("/path", newJSONBodyHandler(cfg))
 					return m
 				},
-				want: func(t *testing.T, resp *http.Response) {
+				want: func(t *testing.T, resp *http.Response, got respBody) {
 					equalVals(t, 201, resp.StatusCode)
-
-					wantHeaders := make(http.Header)
-					wantHeaders.Set("X-Cs-Origin", "fooorigin")
-					wantHeaders.Set("X-Cs-Executionid", "exec_id")
-					wantHeaders.Set("X-Cs-Traceid", "trace_id")
-					containsHeaders(t, wantHeaders, resp.Header)
-
-					var got respBody
-					decodeBody(t, resp.Body, &got)
+					equalVals(t, 201, got.Code)
 
 					if len(got.Errs) > 0 {
 						t.Errorf("received unexpected errors\n\t\tgot:\t%+v", got.Errs)
@@ -170,11 +153,16 @@ func TestRun_httprunner(t *testing.T) {
 
 					echo := got.Req
 
-					equalVals(t, `{"dodgers":"stink","context":{"kings":"stink_too"}}`, string(echo.Req.Body))
+					equalVals(t, `{"dodgers":"stink"}`, string(echo.Req.Body))
 					equalVals(t, `{"kings":"stink_too"}`, string(echo.Req.Context))
 					equalVals(t, config{Str: "val", Int: 1}, echo.Config)
 					equalVals(t, "/path", echo.Req.Path)
 					equalVals(t, "POST", echo.Req.Method)
+
+					wantHeaders := make(http.Header)
+					wantHeaders.Set("X-Cs-Origin", "fooorigin")
+					wantHeaders.Set("X-Cs-Executionid", "exec_id")
+					wantHeaders.Set("X-Cs-Traceid", "trace_id")
 					containsHeaders(t, wantHeaders, echo.Req.Headers)
 				},
 			},
@@ -196,17 +184,9 @@ func TestRun_httprunner(t *testing.T) {
 					m.Put("/path", newJSONBodyHandler(cfg))
 					return m
 				},
-				want: func(t *testing.T, resp *http.Response) {
+				want: func(t *testing.T, resp *http.Response, got respBody) {
 					equalVals(t, 201, resp.StatusCode)
-
-					wantHeaders := make(http.Header)
-					wantHeaders.Set("X-Cs-Origin", "fooorigin")
-					wantHeaders.Set("X-Cs-Executionid", "exec_id")
-					wantHeaders.Set("X-Cs-Traceid", "trace_id")
-					containsHeaders(t, wantHeaders, resp.Header)
-
-					var got respBody
-					decodeBody(t, resp.Body, &got)
+					equalVals(t, 201, got.Code)
 
 					if len(got.Errs) > 0 {
 						t.Errorf("received unexpected errors\n\t\tgot:\t%+v", got.Errs)
@@ -218,6 +198,11 @@ func TestRun_httprunner(t *testing.T) {
 					equalVals(t, config{Str: "val", Int: 1}, echo.Config)
 					equalVals(t, "/path", echo.Req.Path)
 					equalVals(t, "PUT", echo.Req.Method)
+
+					wantHeaders := make(http.Header)
+					wantHeaders.Set("X-Cs-Origin", "fooorigin")
+					wantHeaders.Set("X-Cs-Executionid", "exec_id")
+					wantHeaders.Set("X-Cs-Traceid", "trace_id")
 					containsHeaders(t, wantHeaders, echo.Req.Headers)
 				},
 			},
@@ -243,17 +228,9 @@ func TestRun_httprunner(t *testing.T) {
 					m.Put("/path", newJSONBodyHandler(cfg))
 					return m
 				},
-				want: func(t *testing.T, resp *http.Response) {
+				want: func(t *testing.T, resp *http.Response, got respBody) {
 					equalVals(t, 201, resp.StatusCode)
-
-					wantHeaders := make(http.Header)
-					wantHeaders.Set("X-Cs-Origin", "fooorigin")
-					wantHeaders.Set("X-Cs-Executionid", "exec_id")
-					wantHeaders.Set("X-Cs-Traceid", "trace_id")
-					containsHeaders(t, wantHeaders, resp.Header)
-
-					var got respBody
-					decodeBody(t, resp.Body, &got)
+					equalVals(t, 201, got.Code)
 
 					if len(got.Errs) > 0 {
 						t.Errorf("received unexpected errors\n\t\tgot:\t%+v", got.Errs)
@@ -265,6 +242,11 @@ func TestRun_httprunner(t *testing.T) {
 					equalVals(t, config{Str: "val", Int: 1}, echo.Config)
 					equalVals(t, "/path", echo.Req.Path)
 					equalVals(t, "POST", echo.Req.Method)
+
+					wantHeaders := make(http.Header)
+					wantHeaders.Set("X-Cs-Origin", "fooorigin")
+					wantHeaders.Set("X-Cs-Executionid", "exec_id")
+					wantHeaders.Set("X-Cs-Traceid", "trace_id")
 					containsHeaders(t, wantHeaders, echo.Req.Headers)
 
 				},
@@ -286,17 +268,9 @@ func TestRun_httprunner(t *testing.T) {
 					m.Delete("/found", newJSONBodyHandler(cfg))
 					return m
 				},
-				want: func(t *testing.T, resp *http.Response) {
+				want: func(t *testing.T, resp *http.Response, got respBody) {
 					equalVals(t, 404, resp.StatusCode)
-
-					wantHeaders := make(http.Header)
-					wantHeaders.Set("X-Cs-Origin", "fooorigin")
-					wantHeaders.Set("X-Cs-Executionid", "exec_id")
-					wantHeaders.Set("X-Cs-Traceid", "trace_id")
-					containsHeaders(t, wantHeaders, resp.Header)
-
-					var got respBody
-					decodeBody(t, resp.Body, &got)
+					equalVals(t, 404, got.Code)
 
 					if len(got.Errs) != 1 {
 						t.Fatalf("did not received expected number of errors\n\t\twant:\t1 error\n\t\tgot:\t%+v", got.Errs)
@@ -323,17 +297,9 @@ func TestRun_httprunner(t *testing.T) {
 					m.Get("/should-be-get", newJSONBodyHandler(cfg))
 					return m
 				},
-				want: func(t *testing.T, resp *http.Response) {
+				want: func(t *testing.T, resp *http.Response, got respBody) {
 					equalVals(t, 405, resp.StatusCode)
-
-					wantHeaders := make(http.Header)
-					wantHeaders.Set("X-Cs-Origin", "fooorigin")
-					wantHeaders.Set("X-Cs-Executionid", "exec_id")
-					wantHeaders.Set("X-Cs-Traceid", "trace_id")
-					containsHeaders(t, wantHeaders, resp.Header)
-
-					var got respBody
-					decodeBody(t, resp.Body, &got)
+					equalVals(t, 405, got.Code)
 
 					if len(got.Errs) != 1 {
 						t.Fatalf("did not received expected number of errors\n\t\twant:\t1 error\n\t\tgot:\t%+v", got.Errs)
@@ -360,19 +326,9 @@ func TestRun_httprunner(t *testing.T) {
 					m.Get("/path", newJSONBodyHandler(cfg))
 					return m
 				},
-				want: func(t *testing.T, resp *http.Response) {
+				want: func(t *testing.T, resp *http.Response, got respBody) {
 					equalVals(t, 400, resp.StatusCode)
-
-					wantHeaders := make(http.Header)
-					wantHeaders.Set("X-Cs-Origin", "fooorigin")
-					wantHeaders.Set("X-Cs-Executionid", "exec_id")
-					wantHeaders.Set("X-Cs-Traceid", "trace_id")
-					containsHeaders(t, wantHeaders, resp.Header)
-
-					var got struct {
-						Errs []fdk.APIError `json:"errors"`
-					}
-					decodeBody(t, resp.Body, &got)
+					equalVals(t, 400, got.Code)
 
 					if len(got.Errs) != 1 {
 						t.Fatalf("did not received expected number of errors\n\t\twant:\t1 error\n\t\tgot:\t%+v", got.Errs)
@@ -403,19 +359,9 @@ func TestRun_httprunner(t *testing.T) {
 					m.Post("/path", newJSONBodyHandler(cfg))
 					return m
 				},
-				want: func(t *testing.T, resp *http.Response) {
+				want: func(t *testing.T, resp *http.Response, got respBody) {
 					equalVals(t, http.StatusInternalServerError, resp.StatusCode)
-
-					wantHeaders := make(http.Header)
-					wantHeaders.Set("X-Cs-Origin", "fooorigin")
-					wantHeaders.Set("X-Cs-Executionid", "exec_id")
-					wantHeaders.Set("X-Cs-Traceid", "trace_id")
-					containsHeaders(t, wantHeaders, resp.Header)
-
-					var got struct {
-						Errs []fdk.APIError `json:"errors"`
-					}
-					decodeBody(t, resp.Body, &got)
+					equalVals(t, http.StatusInternalServerError, got.Code)
 
 					if len(got.Errs) != 1 {
 						t.Fatalf("did not received expected number of errors\n\t\twant:\t1 error\n\t\tgot:\t%+v", got.Errs)
@@ -461,38 +407,51 @@ func TestRun_httprunner(t *testing.T) {
 				case <-time.After(50 * time.Millisecond):
 				}
 
-				var reqBody io.Reader
-				if len(tt.inputs.body) > 0 {
-					reqBody = bytes.NewBuffer(tt.inputs.body)
+				body := struct {
+					AccessToken string          `json:"access_token"`
+					Body        json.RawMessage `json:"body"`
+					Context     json.RawMessage `json:"context"`
+					Method      string          `json:"method"`
+					Params      struct {
+						Header http.Header `json:"header"`
+						Query  url.Values  `json:"query"`
+					} `json:"params"`
+					URL string `json:"url"`
+				}{
+					Body: tt.inputs.body,
+					Params: struct {
+						Header http.Header `json:"header"`
+						Query  url.Values  `json:"query"`
+					}{
+						Header: tt.inputs.headers,
+						Query:  tt.inputs.queryParams,
+					},
+					URL:         tt.inputs.path,
+					Method:      tt.inputs.method,
+					Context:     tt.inputs.context,
+					AccessToken: tt.inputs.accessToken,
 				}
+
+				b, err := json.Marshal(body)
+				mustNoErr(t, err)
 
 				req, err := http.NewRequestWithContext(
 					ctx,
-					tt.inputs.method,
-					"http://localhost:"+port+path.Join("/", tt.inputs.path),
-					reqBody,
+					http.MethodPost,
+					"http://localhost:"+port,
+					bytes.NewBuffer(b),
 				)
 				mustNoErr(t, err)
-
-				for h, vals := range tt.inputs.headers {
-					for _, v := range vals {
-						req.Header.Add(h, v)
-					}
-				}
-
-				q := req.URL.Query()
-				for name, vals := range tt.inputs.queryParams {
-					for _, v := range vals {
-						q.Add(name, v)
-					}
-				}
-				req.URL.RawQuery = q.Encode()
 
 				resp, err := http.DefaultClient.Do(req)
 				mustNoErr(t, err)
 				cancel()
+				defer func() { _ = resp.Body.Close() }()
 
-				tt.want(t, resp)
+				var got respBody
+				decodeBody(t, resp.Body, &got)
+
+				tt.want(t, resp, got)
 			}
 			t.Run(tt.name, fn)
 		}
@@ -519,8 +478,10 @@ func (c config) OK() error {
 
 type (
 	respBody struct {
-		Errs []fdk.APIError `json:"errors"`
-		Req  echoReq        `json:"body"`
+		Code    int            `json:"code"`
+		Errs    []fdk.APIError `json:"errors"`
+		Headers http.Header    `json:"headers"`
+		Req     echoReq        `json:"body"`
 	}
 
 	echoReq struct {
@@ -625,6 +586,7 @@ func decodeBody(t testing.TB, r io.Reader, v any) {
 	if err != nil {
 		t.Fatal("failed to read: " + err.Error())
 	}
+	fmt.Println("body: ", string(b))
 
 	err = json.Unmarshal(b, v)
 	if err != nil {


### PR DESCRIPTION
this came up recently. The previous shape of the local http runner is out of step with the legacy version. The ask is to keep parity with the legacy v0.3.0 version going forward.