### PR TITLE
chore: extend FS config loader to allow yaml configs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Go
       uses: actions/setup-go@v4


### PR DESCRIPTION
one bit of issue we have with running funcs locally, is the ability to write a yaml config, which is accepted by the faas backend, but locally it does not support it. This is a small change to load the config and if its yaml convert it to a normalized json value as expected by the Run func.