### PR TITLE
chore: add Error behavior to APIError type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21
 require (
 	github.com/crowdstrike/gofalcon v0.4.2
 	github.com/xeipuuv/gojsonschema v1.2.0
+	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (
@@ -39,6 +40,5 @@ require (
 	golang.org/x/sys v0.11.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/sdk.go
+++ b/sdk.go
@@ -3,6 +3,7 @@ package fdk
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -109,13 +110,18 @@ type (
 		Method      string
 		AccessToken string
 	}
-
-	// APIError defines a error that is shared back to the caller.
-	APIError struct {
-		Code    int    `json:"code"`
-		Message string `json:"message"`
-	}
 )
+
+// APIError defines a error that is shared back to the caller.
+type APIError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// Error provides a human readable error message.
+func (a APIError) Error() string {
+	return fmt.Sprintf("[%d] %s", a.Code, a.Message)
+}
 
 // Response is the domain type for the response.
 type Response struct {

--- a/sdk_test.go
+++ b/sdk_test.go
@@ -1,6 +1,8 @@
 package fdk_test
 
 import (
+	"fmt"
+	"net/http"
 	"testing"
 
 	fdk "github.com/CrowdStrike/foundry-fn-go"
@@ -55,4 +57,16 @@ func TestFn(t *testing.T) {
 		})
 	}
 
+}
+
+func TestAPIError(t *testing.T) {
+	errs := []fdk.APIError{
+		{Code: http.StatusInternalServerError, Message: "some internal error"},
+		{Code: http.StatusBadRequest, Message: "user dorked it up"},
+		{Message: "missing code will print a zero"},
+	}
+	for _, err := range errs {
+		want := fmt.Sprintf("[%d] %s", err.Code, err.Message)
+		equalVals(t, want, err.Error())
+	}
 }


### PR DESCRIPTION
this enables the APIError to satisfy the error interface, allowing it to be propagated up a callstack without conversion.