### PR TITLE
feat: add zip file func to simplify working with gzip encoding

### DIFF
--- a/file.go
+++ b/file.go
@@ -1,0 +1,101 @@
+package fdk
+
+import (
+	"compress/gzip"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"sync"
+	"sync/atomic"
+)
+
+// File represents a response that is a response body. The runner is in charge
+// of getting the contents to the destination. The metadata will be received.
+type File struct {
+	ContentType string        `json:"content_type"`
+	Encoding    string        `json:"encoding"`
+	Filename    string        `json:"filename"`
+	Contents    io.ReadCloser `json:"-"`
+}
+
+// MarshalJSON marshals the file metadata.
+func (f File) MarshalJSON() ([]byte, error) {
+	type alias File
+	return json.Marshal(alias(f))
+}
+
+// CompressGzip compresses a files contents with gzip compression.
+func CompressGzip(file File) File {
+	switch {
+	case file.Encoding == "":
+		file.Encoding = "gzip"
+	case file.Encoding != "" && !strings.Contains(file.Encoding, "gzip"):
+		file.Encoding += ", gzip"
+	}
+	file.Contents = newCompressorGzip(file.Contents)
+	return file
+}
+
+type compressorGzip struct {
+	rc io.ReadCloser
+	pr *io.PipeReader
+
+	pwClosed bool
+	pw       *io.PipeWriter
+	gwClosed bool
+	gw       *gzip.Writer
+
+	mu       sync.Mutex
+	started  atomic.Int32
+	closeErr error
+	copyErr  error
+}
+
+func newCompressorGzip(rc io.ReadCloser) *compressorGzip {
+	pr, pw := io.Pipe()
+	return &compressorGzip{
+		rc: rc,
+		pw: pw,
+		pr: pr,
+		gw: gzip.NewWriter(pw),
+	}
+}
+
+func (c *compressorGzip) Read(p []byte) (int, error) {
+	if c.started.CompareAndSwap(0, 1) {
+		go c.compressInput()
+	}
+	return c.pr.Read(p)
+}
+
+func (c *compressorGzip) compressInput() {
+	defer func() {
+		c.gwClosed, c.pwClosed = true, true
+		err := c.pw.CloseWithError(c.gw.Close())
+		c.mu.Lock()
+		c.closeErr = err
+		c.mu.Unlock()
+	}()
+	if _, err := io.Copy(c.gw, c.rc); err != nil && !errors.Is(err, io.EOF) {
+		c.mu.Lock()
+		c.copyErr = err
+		c.mu.Unlock()
+	}
+}
+
+func (c *compressorGzip) Close() error {
+	c.mu.Lock()
+	errs := []error{c.closeErr, c.copyErr}
+	c.mu.Unlock()
+	if !c.gwClosed {
+		errs = append(errs, c.gw.Close())
+	}
+	if !c.pwClosed {
+		errs = append(errs, c.pw.Close())
+	}
+
+	errs = append(errs, c.rc.Close(), c.pr.Close())
+
+	return errors.Join(errs...)
+}

--- a/file_test.go
+++ b/file_test.go
@@ -1,0 +1,44 @@
+package fdk_test
+
+import (
+	"testing"
+
+	fdk "github.com/CrowdStrike/foundry-fn-go"
+)
+
+func TestCompressGzip(t *testing.T) {
+	f := fdk.CompressGzip(fdk.File{
+		ContentType: "text/yaml",
+		Encoding:    "",
+	})
+	equalVals(t, "text/yaml", f.ContentType)
+	equalVals(t, "gzip", f.Encoding)
+
+	f = fdk.CompressGzip(fdk.File{
+		ContentType: "application/json",
+		Encoding:    "gzip",
+	})
+	equalVals(t, "application/json", f.ContentType)
+	equalVals(t, "gzip", f.Encoding)
+
+	f = fdk.CompressGzip(fdk.File{
+		ContentType: "text/plain",
+		Encoding:    "deflate",
+	})
+	equalVals(t, "text/plain", f.ContentType)
+	equalVals(t, "deflate, gzip", f.Encoding)
+
+	f = fdk.CompressGzip(fdk.File{
+		ContentType: "text/plain",
+		Encoding:    "gzip, deflate",
+	})
+	equalVals(t, "text/plain", f.ContentType)
+	equalVals(t, "gzip, deflate", f.Encoding)
+
+	f = fdk.CompressGzip(fdk.File{
+		ContentType: "application/octet-stream",
+		Encoding:    "kstd, deflate",
+	})
+	equalVals(t, "application/octet-stream", f.ContentType)
+	equalVals(t, "kstd, deflate, gzip", f.Encoding)
+}

--- a/runner_test.go
+++ b/runner_test.go
@@ -2,6 +2,7 @@ package fdk_test
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -748,7 +749,7 @@ integer: 1`,
 				},
 			},
 			{
-				name: "POST to a endpoint that returns a sdk.File with encoding should pass",
+				name: "POST to an endpoint that returns a sdk.File with encoding should pass",
 				input: inputs{
 					body: newReqBody(t, fileInReq{
 						ContentType: "application/json",
@@ -777,10 +778,37 @@ integer: 1`,
 					equalFiles(t, got.Filename, `{"dodgers":"stink"}`)
 				},
 			},
+			{
+				name: "POST to an endpoint that returns a gzip compressed sdk.File should pass",
+				input: inputs{
+					body: newReqBody(t, fileInReq{
+						ContentType:  "application/json",
+						DestFilename: filepath.Join(tmp, "third_file.json"),
+						V:            `{"dodgers":"reallystank"}`,
+					}),
+					method: "POST",
+					path:   "/compress-file",
+				},
+				newHandlerFn: func(ctx context.Context) fdk.Handler {
+					m := fdk.NewMux()
+					m.Post("/compress-file", fdk.HandleFnOf(newGzippedFileHandler))
+					return m
+				},
+				want: func(t *testing.T, resp *http.Response, got fdk.File) {
+					equalVals(t, 201, resp.StatusCode)
+
+					equalVals(t, "application/json", got.ContentType)
+					equalVals(t, "gzip", got.Encoding)
+
+					wantFilename := filepath.Join(tmp, "third_file.json")
+					equalVals(t, wantFilename, got.Filename)
+					equalGzipFiles(t, got.Filename, `{"dodgers":"reallystank"}`)
+				},
+			},
 		}
 
 		for _, tt := range tests {
-			fn := func(t *testing.T) {
+			t.Run(tt.name, func(t *testing.T) {
 				ctx, cancel := context.WithCancel(context.Background())
 				defer cancel()
 
@@ -814,8 +842,7 @@ integer: 1`,
 				mustNoErr(t, json.Unmarshal(b, &got))
 
 				tt.want(t, resp, got.File)
-			}
-			t.Run(tt.name, fn)
+			})
 		}
 	})
 }
@@ -928,8 +955,20 @@ func newFileHandler(_ context.Context, r fdk.RequestOf[fileInReq]) fdk.Response 
 			ContentType: r.Body.ContentType,
 			Encoding:    r.Body.Encoding,
 			Filename:    r.Body.DestFilename,
-			Contents:    strings.NewReader(r.Body.V),
+			Contents:    io.NopCloser(strings.NewReader(r.Body.V)),
 		},
+	}
+}
+
+func newGzippedFileHandler(_ context.Context, r fdk.RequestOf[fileInReq]) fdk.Response {
+	return fdk.Response{
+		Code: 201,
+		Body: fdk.CompressGzip(fdk.File{
+			ContentType: r.Body.ContentType,
+			Encoding:    r.Body.Encoding,
+			Filename:    r.Body.DestFilename,
+			Contents:    io.NopCloser(strings.NewReader(r.Body.V)),
+		}),
 	}
 }
 
@@ -946,7 +985,35 @@ func equalVals[T comparable](t testing.TB, want, got T) bool {
 func equalFiles(t testing.TB, filename string, want string) {
 	t.Helper()
 
-	b, err := os.ReadFile(filename)
+	f, err := os.Open(filename)
+	mustNoErr(t, err)
+	defer func() { _ = f.Close() }()
+
+	equalReader(t, want, f)
+
+	err = f.Close()
+	if err != nil {
+		t.Errorf("failed to close file: " + err.Error())
+	}
+}
+
+func equalGzipFiles(t testing.TB, filename string, want string) {
+	t.Helper()
+
+	f, err := os.Open(filename)
+	mustNoErr(t, err)
+	defer func() { _ = f.Close() }()
+
+	gr, err := gzip.NewReader(f)
+	mustNoErr(t, err)
+
+	equalReader(t, want, gr)
+}
+
+func equalReader(t testing.TB, want string, got io.Reader) {
+	t.Helper()
+
+	b, err := io.ReadAll(got)
 	mustNoErr(t, err)
 
 	equalVals(t, want, string(b))

--- a/sdk.go
+++ b/sdk.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -196,21 +195,6 @@ type jsoned struct {
 
 func (j jsoned) MarshalJSON() ([]byte, error) {
 	return json.Marshal(j.v)
-}
-
-// File represents a response that is a response body. The runner is in charge
-// of getting the contents to the destination. The metadata will be received.
-type File struct {
-	ContentType string        `json:"content_type"`
-	Encoding    string        `json:"encoding"`
-	Filename    string        `json:"filename"`
-	Contents    io.ReadSeeker `json:"-"`
-}
-
-// MarshalJSON marshals the file metadata.
-func (f File) MarshalJSON() ([]byte, error) {
-	type alias File
-	return json.Marshal(alias(f))
 }
 
 // ErrHandler creates a new handler to respond with only errors.


### PR DESCRIPTION
This also changes the File.Contents to a `ReadCloser` type. After more experimenting with this, we really want to be able to support the closing behavior.