### PR TITLE
chore: add File normalizer and utilize in runner

### DIFF
--- a/file.go
+++ b/file.go
@@ -5,13 +5,35 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"mime"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 )
 
+var initMime = func() func() {
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			_ = mime.AddExtensionType(".xml", "application/xml")
+			_ = mime.AddExtensionType(".jsonld", "application/ld+json")
+			_ = mime.AddExtensionType(".jsonnet", "application/jsonnet")
+			_ = mime.AddExtensionType(".yaml", "text/yaml")
+			_ = mime.AddExtensionType(".yml", "text/yaml")
+		})
+	}
+}()
+
+const contentTypeOctetStream = "application/octet-stream"
+
+var nowFn = time.Now
+
 // File represents a response that is a response body. The runner is in charge
-// of getting the contents to the destination. The metadata will be received.
+// of getting the contents to the destination. The metadata will be received. One
+// note, we call NormalizeFile on the File's in the Runner's that execute the handler.
+// Testing through the Run function will illustrate this.
 type File struct {
 	ContentType string        `json:"content_type"`
 	Encoding    string        `json:"encoding"`
@@ -23,6 +45,20 @@ type File struct {
 func (f File) MarshalJSON() ([]byte, error) {
 	type alias File
 	return json.Marshal(alias(f))
+}
+
+// NormalizeFile normalizes a file so that all fields are set with sane defaults.
+func NormalizeFile(f File) File {
+	if f.ContentType == "" {
+		f.ContentType = normalizeContentType(f.Filename)
+	}
+	if f.Encoding == "" {
+		f.Encoding = normalizeEncoding(f.Filename)
+	}
+	if f.Filename == "" {
+		f.Filename = normalizeFilename(f.ContentType, f.Encoding, nowFn())
+	}
+	return f
 }
 
 // CompressGzip compresses a files contents with gzip compression.
@@ -98,4 +134,69 @@ func (c *compressorGzip) Close() error {
 	errs = append(errs, c.rc.Close(), c.pr.Close())
 
 	return errors.Join(errs...)
+}
+
+func normalizeContentType(filename string) string {
+	initMime()
+	parts := strings.Split(filepath.Base(filename), ".")
+	if len(parts) < 2 {
+		return contentTypeOctetStream
+	}
+	for _, ext := range parts[1:] {
+		if ct := mime.TypeByExtension("." + ext); ct != "" {
+			return ct
+		}
+	}
+	return contentTypeOctetStream
+}
+
+func normalizeEncoding(filename string) string {
+	parts := strings.SplitN(filepath.Base(filename), ".", 2)
+	if len(parts) == 1 {
+		return ""
+	}
+
+	mapping := map[string]string{
+		"br":  "brotli",
+		"gz":  "gzip",
+		"zst": "zstd",
+	}
+	var out []string
+	for _, part := range strings.Split(parts[1], ".") {
+		if encoding, ok := mapping[part]; ok {
+			out = append(out, encoding)
+		}
+	}
+	return strings.Join(out, ", ")
+}
+
+var compressionToExt = map[string]string{
+	"brotli": "br",
+	"gzip":   "gz",
+	"zstd":   "zst",
+}
+
+func normalizeFilename(contentType, encoding string, now time.Time) string {
+	filename := "upload_" + now.Format(time.RFC3339)
+	if encoding != "" {
+		var converted []string
+		for _, enc := range strings.Split(strings.ReplaceAll(encoding, " ", ""), ",") {
+			if ext := compressionToExt[enc]; ext != "" {
+				converted = append(converted, ext)
+			}
+		}
+		if len(converted) > 0 {
+			encoding = "." + strings.Join(converted, ".")
+		}
+	}
+
+	var ctExt string
+	if contentType != contentTypeOctetStream {
+		initMime()
+		exts, _ := mime.ExtensionsByType(contentType)
+		if len(exts) > 0 {
+			ctExt = exts[0]
+		}
+	}
+	return filename + ctExt + encoding
 }

--- a/file_internal_test.go
+++ b/file_internal_test.go
@@ -1,0 +1,257 @@
+package fdk
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNormalizeFile(t *testing.T) {
+	var start = time.Time{}.UTC().Add(time.Hour)
+
+	tests := []struct {
+		name  string
+		nowFn func() time.Time
+		in    File
+		want  File
+	}{
+		{
+			name: "file with all values set should remain the same",
+			in: File{
+				ContentType: "application/json",
+				Encoding:    "gzip",
+				Filename:    "test.json",
+			},
+			want: File{
+				ContentType: "application/json",
+				Encoding:    "gzip",
+				Filename:    "test.json",
+			},
+		},
+		{
+			name: "file missing encoding should remain the same",
+			in: File{
+				ContentType: "application/json",
+				Filename:    "test.json",
+			},
+			want: File{
+				ContentType: "application/json",
+				Filename:    "test.json",
+			},
+		},
+		{
+			name: "file missing content type for filename with json extension should add content type to application/ld+json",
+			in: File{
+				Filename: "test.jsonld",
+			},
+			want: File{
+				ContentType: "application/ld+json",
+				Filename:    "test.jsonld",
+			},
+		},
+		{
+			name: "file missing content type for filename with jsonld extension should add content type to application/json",
+			in: File{
+				Filename: "test.json",
+			},
+			want: File{
+				ContentType: "application/json",
+				Filename:    "test.json",
+			},
+		},
+		{
+			name: "file missing content type for filename with jsonld extension should add content type to application/json",
+			in: File{
+				Filename: "test.js",
+			},
+			want: File{
+				ContentType: "text/javascript; charset=utf-8",
+				Filename:    "test.js",
+			},
+		},
+		{
+			name: "file missing content type for filename with xml extension should add content type to application/xml",
+			in: File{
+				Filename: "test.xml",
+			},
+			want: File{
+				ContentType: "application/xml",
+				Filename:    "test.xml",
+			},
+		},
+		{
+			name: "file missing content type for filename with tar extension should add content type to application/x-tar",
+			in: File{
+				Filename: "test.tar",
+			},
+			want: File{
+				ContentType: "application/x-tar",
+				Filename:    "test.tar",
+			},
+		},
+		{
+			name: "file missing content type for filename with zip extension should add content type to application/zip",
+			in: File{
+				Filename: "test.zip",
+			},
+			want: File{
+				ContentType: "application/zip",
+				Filename:    "test.zip",
+			},
+		},
+		{
+			name: "file missing content type for filename with html extension should add content type to text/html",
+			in: File{
+				Filename: "test.html",
+			},
+			want: File{
+				ContentType: "text/html; charset=utf-8",
+				Filename:    "test.html",
+			},
+		},
+		{
+			name: "file missing content type for filename with yaml extension should add content type to text/yaml",
+			in: File{
+				Filename: "test.yaml",
+			},
+			want: File{
+				ContentType: "text/yaml; charset=utf-8",
+				Filename:    "test.yaml",
+			},
+		},
+		{
+			name: "file missing content type for filename with yml extension should add content type to text/yaml",
+			in: File{
+				Filename: "test.yml",
+			},
+			want: File{
+				ContentType: "text/yaml; charset=utf-8",
+				Filename:    "test.yml",
+			},
+		},
+		{
+			name: "file missing content type for filename with txt extension should add content type to text/plain",
+			in: File{
+				Filename: "test.txt",
+			},
+			want: File{
+				ContentType: "text/plain; charset=utf-8",
+				Filename:    "test.txt",
+			},
+		},
+		{
+			name: "file missing content encoding for gzipped json filename should add content type and encoding",
+			in: File{
+				Filename: "test.json.gz",
+			},
+			want: File{
+				ContentType: "application/json",
+				Encoding:    "gzip",
+				Filename:    "test.json.gz",
+			},
+		},
+		{
+			name: "file missing content encoding for gzipped yaml filename should add content type and encoding",
+			in: File{
+				Filename: "test.yaml.gz",
+			},
+			want: File{
+				ContentType: "text/yaml; charset=utf-8",
+				Encoding:    "gzip",
+				Filename:    "test.yaml.gz",
+			},
+		},
+		{
+			name: "file missing content type and filename should set filename to timestamp",
+			nowFn: func() time.Time {
+				return start
+			},
+			in: File{},
+			want: File{
+				ContentType: "application/octet-stream",
+				Filename:    "upload_" + start.Format(time.RFC3339),
+			},
+		},
+		{
+			name: "file missing filename with content type json set filename to timestamp.json file",
+			nowFn: func() time.Time {
+				return start
+			},
+			in: File{
+				ContentType: "application/json",
+			},
+			want: File{
+				ContentType: "application/json",
+				Filename:    "upload_" + start.Format(time.RFC3339) + ".json",
+			},
+		},
+		{
+			name: "file missing filename with content type json and gz encoding set filename to timestamp.json.gz file",
+			nowFn: func() time.Time {
+				return start
+			},
+			in: File{
+				ContentType: "application/json",
+				Encoding:    "gzip",
+			},
+			want: File{
+				ContentType: "application/json",
+				Encoding:    "gzip",
+				Filename:    "upload_" + start.Format(time.RFC3339) + ".json.gz",
+			},
+		},
+		{
+			name: "file missing filename with content type json and gz zstd encodings set filename to timestamp.json.gz file",
+			nowFn: func() time.Time {
+				return start
+			},
+			in: File{
+				ContentType: "application/json",
+				Encoding:    "zstd, gzip",
+			},
+			want: File{
+				ContentType: "application/json",
+				Encoding:    "zstd, gzip",
+				Filename:    "upload_" + start.Format(time.RFC3339) + ".json.zst.gz",
+			},
+		},
+		{
+			name: "file missing filename with content type plain/javascript and gz zstd encodings set filename to timestamp.json.gz file",
+			nowFn: func() time.Time {
+				return start
+			},
+			in: File{
+				ContentType: "text/javascript; charset=utf-8",
+				Encoding:    "zstd, gzip",
+			},
+			want: File{
+				ContentType: "text/javascript; charset=utf-8",
+				Encoding:    "zstd, gzip",
+				Filename:    "upload_" + start.Format(time.RFC3339) + ".js.zst.gz",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.nowFn != nil {
+				old := nowFn
+				nowFn = tt.nowFn
+				t.Cleanup(func() { nowFn = old })
+			}
+
+			got := NormalizeFile(tt.in)
+			EqualVals(t, tt.want.Filename, got.Filename)
+			EqualVals(t, tt.want.ContentType, got.ContentType)
+			EqualVals(t, tt.want.Encoding, got.Encoding)
+		})
+	}
+}
+
+func EqualVals[T comparable](t testing.TB, want, got T) bool {
+	t.Helper()
+
+	match := want == got
+	if !match {
+		t.Errorf("values not equal:\n\t\twant:\t%#v\n\t\tgot:\t%#v", want, got)
+	}
+	return match
+}

--- a/file_test.go
+++ b/file_test.go
@@ -11,34 +11,34 @@ func TestCompressGzip(t *testing.T) {
 		ContentType: "text/yaml",
 		Encoding:    "",
 	})
-	equalVals(t, "text/yaml", f.ContentType)
-	equalVals(t, "gzip", f.Encoding)
+	fdk.EqualVals(t, "text/yaml", f.ContentType)
+	fdk.EqualVals(t, "gzip", f.Encoding)
 
 	f = fdk.CompressGzip(fdk.File{
 		ContentType: "application/json",
 		Encoding:    "gzip",
 	})
-	equalVals(t, "application/json", f.ContentType)
-	equalVals(t, "gzip", f.Encoding)
+	fdk.EqualVals(t, "application/json", f.ContentType)
+	fdk.EqualVals(t, "gzip", f.Encoding)
 
 	f = fdk.CompressGzip(fdk.File{
 		ContentType: "text/plain",
 		Encoding:    "deflate",
 	})
-	equalVals(t, "text/plain", f.ContentType)
-	equalVals(t, "deflate, gzip", f.Encoding)
+	fdk.EqualVals(t, "text/plain", f.ContentType)
+	fdk.EqualVals(t, "deflate, gzip", f.Encoding)
 
 	f = fdk.CompressGzip(fdk.File{
 		ContentType: "text/plain",
 		Encoding:    "gzip, deflate",
 	})
-	equalVals(t, "text/plain", f.ContentType)
-	equalVals(t, "gzip, deflate", f.Encoding)
+	fdk.EqualVals(t, "text/plain", f.ContentType)
+	fdk.EqualVals(t, "gzip, deflate", f.Encoding)
 
 	f = fdk.CompressGzip(fdk.File{
 		ContentType: "application/octet-stream",
 		Encoding:    "kstd, deflate",
 	})
-	equalVals(t, "application/octet-stream", f.ContentType)
-	equalVals(t, "kstd, deflate, gzip", f.Encoding)
+	fdk.EqualVals(t, "application/octet-stream", f.ContentType)
+	fdk.EqualVals(t, "kstd, deflate, gzip", f.Encoding)
 }

--- a/runner_http.go
+++ b/runner_http.go
@@ -41,6 +41,7 @@ func (r *runnerHTTP) Run(ctx context.Context, logger *slog.Logger, h Handler) {
 		resp := h.Handle(ctx, r)
 
 		if f, ok := resp.Body.(File); ok {
+			f = NormalizeFile(f)
 			err := writeFile(logger, f.Contents, f.Filename)
 			if err != nil {
 				resp.Errors = append(resp.Errors, APIError{Code: http.StatusInternalServerError, Message: err.Error()})
@@ -51,6 +52,7 @@ func (r *runnerHTTP) Run(ctx context.Context, logger *slog.Logger, h Handler) {
 				return
 			}
 			f.Contents = nil
+			resp.Body = f
 		}
 
 		err = writeResponse(logger, w, resp)

--- a/runner_test.go
+++ b/runner_test.go
@@ -79,21 +79,21 @@ func TestRun_httprunner(t *testing.T) {
 					return m
 				},
 				want: func(t *testing.T, resp *http.Response, got respBody) {
-					equalVals(t, 201, resp.StatusCode)
-					equalVals(t, 201, got.Code)
+					fdk.EqualVals(t, 201, resp.StatusCode)
+					fdk.EqualVals(t, 201, got.Code)
 
 					if len(got.Errs) > 0 {
 						t.Errorf("received unexpected errors\n\t\tgot:\t%+v", got.Errs)
 					}
 
 					echo := got.Req
-					equalVals(t, config{Str: "val", Int: 1}, echo.Config)
+					fdk.EqualVals(t, config{Str: "val", Int: 1}, echo.Config)
 
-					equalVals(t, "/path", echo.Req.Path)
-					equalVals(t, "DELETE", echo.Req.Method)
-					equalVals(t, "id1", echo.Req.Queries.Get("ids"))
-					equalVals(t, "trace1", echo.Req.TraceID)
-					equalVals(t, "trace1", echo.Req.CtxTraceID)
+					fdk.EqualVals(t, "/path", echo.Req.Path)
+					fdk.EqualVals(t, "DELETE", echo.Req.Method)
+					fdk.EqualVals(t, "id1", echo.Req.Queries.Get("ids"))
+					fdk.EqualVals(t, "trace1", echo.Req.TraceID)
+					fdk.EqualVals(t, "trace1", echo.Req.CtxTraceID)
 
 					wantHeaders := make(http.Header)
 					wantHeaders.Set("X-Cs-Origin", "fooorigin")
@@ -124,19 +124,19 @@ integer: 1`,
 					return m
 				},
 				want: func(t *testing.T, resp *http.Response, got respBody) {
-					equalVals(t, 201, resp.StatusCode)
-					equalVals(t, 201, got.Code)
+					fdk.EqualVals(t, 201, resp.StatusCode)
+					fdk.EqualVals(t, 201, got.Code)
 
 					if len(got.Errs) > 0 {
 						t.Errorf("received unexpected errors\n\t\tgot:\t%+v", got.Errs)
 					}
 
 					echo := got.Req
-					equalVals(t, config{Str: "val", Int: 1}, echo.Config)
+					fdk.EqualVals(t, config{Str: "val", Int: 1}, echo.Config)
 
-					equalVals(t, "/path", echo.Req.Path)
-					equalVals(t, "DELETE", echo.Req.Method)
-					equalVals(t, "id1", echo.Req.Queries.Get("ids"))
+					fdk.EqualVals(t, "/path", echo.Req.Path)
+					fdk.EqualVals(t, "DELETE", echo.Req.Method)
+					fdk.EqualVals(t, "id1", echo.Req.Queries.Get("ids"))
 
 					wantHeaders := make(http.Header)
 					wantHeaders.Set("X-Cs-Origin", "fooorigin")
@@ -167,19 +167,19 @@ integer: 1`,
 					return m
 				},
 				want: func(t *testing.T, resp *http.Response, got respBody) {
-					equalVals(t, 201, resp.StatusCode)
-					equalVals(t, 201, got.Code)
+					fdk.EqualVals(t, 201, resp.StatusCode)
+					fdk.EqualVals(t, 201, got.Code)
 
 					if len(got.Errs) > 0 {
 						t.Errorf("received unexpected errors\n\t\tgot:\t%+v", got.Errs)
 					}
 
 					echo := got.Req
-					equalVals(t, config{Str: "val", Int: 1}, echo.Config)
+					fdk.EqualVals(t, config{Str: "val", Int: 1}, echo.Config)
 
-					equalVals(t, "/path", echo.Req.Path)
-					equalVals(t, "DELETE", echo.Req.Method)
-					equalVals(t, "id1", echo.Req.Queries.Get("ids"))
+					fdk.EqualVals(t, "/path", echo.Req.Path)
+					fdk.EqualVals(t, "DELETE", echo.Req.Method)
+					fdk.EqualVals(t, "id1", echo.Req.Queries.Get("ids"))
 
 					wantHeaders := make(http.Header)
 					wantHeaders.Set("X-Cs-Origin", "fooorigin")
@@ -207,19 +207,19 @@ integer: 1`,
 					return m
 				},
 				want: func(t *testing.T, resp *http.Response, got respBody) {
-					equalVals(t, 201, resp.StatusCode)
-					equalVals(t, 201, got.Code)
+					fdk.EqualVals(t, 201, resp.StatusCode)
+					fdk.EqualVals(t, 201, got.Code)
 
 					if len(got.Errs) > 0 {
 						t.Errorf("received unexpected errors\n\t\tgot:\t%+v", got.Errs)
 					}
 
 					echo := got.Req
-					equalVals(t, config{Str: "val", Int: 1}, echo.Config)
+					fdk.EqualVals(t, config{Str: "val", Int: 1}, echo.Config)
 
-					equalVals(t, "GET", echo.Req.Method)
-					equalVals(t, "/path", echo.Req.Path)
-					equalVals(t, "baz", echo.Req.Queries.Get("bar"))
+					fdk.EqualVals(t, "GET", echo.Req.Method)
+					fdk.EqualVals(t, "/path", echo.Req.Path)
+					fdk.EqualVals(t, "baz", echo.Req.Queries.Get("bar"))
 
 					wantHeaders := make(http.Header)
 					wantHeaders.Set("X-Cs-Origin", "fooorigin")
@@ -248,8 +248,8 @@ integer: 1`,
 					return m
 				},
 				want: func(t *testing.T, resp *http.Response, got respBody) {
-					equalVals(t, 201, resp.StatusCode)
-					equalVals(t, 201, got.Code)
+					fdk.EqualVals(t, 201, resp.StatusCode)
+					fdk.EqualVals(t, 201, got.Code)
 
 					if len(got.Errs) > 0 {
 						t.Errorf("received unexpected errors\n\t\tgot:\t%+v", got.Errs)
@@ -257,11 +257,11 @@ integer: 1`,
 
 					echo := got.Req
 
-					equalVals(t, `{"dodgers":"stink"}`, string(echo.Req.Body))
-					equalVals(t, `{"kings":"stink_too"}`, string(echo.Req.Context))
-					equalVals(t, config{Str: "val", Int: 1}, echo.Config)
-					equalVals(t, "/path", echo.Req.Path)
-					equalVals(t, "POST", echo.Req.Method)
+					fdk.EqualVals(t, `{"dodgers":"stink"}`, string(echo.Req.Body))
+					fdk.EqualVals(t, `{"kings":"stink_too"}`, string(echo.Req.Context))
+					fdk.EqualVals(t, config{Str: "val", Int: 1}, echo.Config)
+					fdk.EqualVals(t, "/path", echo.Req.Path)
+					fdk.EqualVals(t, "POST", echo.Req.Method)
 
 					wantHeaders := make(http.Header)
 					wantHeaders.Set("X-Cs-Origin", "fooorigin")
@@ -289,8 +289,8 @@ integer: 1`,
 					return m
 				},
 				want: func(t *testing.T, resp *http.Response, got respBody) {
-					equalVals(t, 201, resp.StatusCode)
-					equalVals(t, 201, got.Code)
+					fdk.EqualVals(t, 201, resp.StatusCode)
+					fdk.EqualVals(t, 201, got.Code)
 
 					if len(got.Errs) > 0 {
 						t.Errorf("received unexpected errors\n\t\tgot:\t%+v", got.Errs)
@@ -298,10 +298,10 @@ integer: 1`,
 
 					echo := got.Req
 
-					equalVals(t, `{"dodgers":"still stink"}`, string(echo.Req.Body))
-					equalVals(t, config{Str: "val", Int: 1}, echo.Config)
-					equalVals(t, "/path", echo.Req.Path)
-					equalVals(t, "PUT", echo.Req.Method)
+					fdk.EqualVals(t, `{"dodgers":"still stink"}`, string(echo.Req.Body))
+					fdk.EqualVals(t, config{Str: "val", Int: 1}, echo.Config)
+					fdk.EqualVals(t, "/path", echo.Req.Path)
+					fdk.EqualVals(t, "PUT", echo.Req.Method)
 
 					wantHeaders := make(http.Header)
 					wantHeaders.Set("X-Cs-Origin", "fooorigin")
@@ -333,8 +333,8 @@ integer: 1`,
 					return m
 				},
 				want: func(t *testing.T, resp *http.Response, got respBody) {
-					equalVals(t, 201, resp.StatusCode)
-					equalVals(t, 201, got.Code)
+					fdk.EqualVals(t, 201, resp.StatusCode)
+					fdk.EqualVals(t, 201, got.Code)
 
 					if len(got.Errs) > 0 {
 						t.Errorf("received unexpected errors\n\t\tgot:\t%+v", got.Errs)
@@ -342,10 +342,10 @@ integer: 1`,
 
 					echo := got.Req
 
-					equalVals(t, `{"dodgers":"stink"}`, string(echo.Req.Body))
-					equalVals(t, config{Str: "val", Int: 1}, echo.Config)
-					equalVals(t, "/path", echo.Req.Path)
-					equalVals(t, "POST", echo.Req.Method)
+					fdk.EqualVals(t, `{"dodgers":"stink"}`, string(echo.Req.Body))
+					fdk.EqualVals(t, config{Str: "val", Int: 1}, echo.Config)
+					fdk.EqualVals(t, "/path", echo.Req.Path)
+					fdk.EqualVals(t, "POST", echo.Req.Method)
 
 					wantHeaders := make(http.Header)
 					wantHeaders.Set("X-Cs-Origin", "fooorigin")
@@ -373,15 +373,15 @@ integer: 1`,
 					return m
 				},
 				want: func(t *testing.T, resp *http.Response, got respBody) {
-					equalVals(t, 404, resp.StatusCode)
-					equalVals(t, 404, got.Code)
+					fdk.EqualVals(t, 404, resp.StatusCode)
+					fdk.EqualVals(t, 404, got.Code)
 
 					if len(got.Errs) != 1 {
 						t.Fatalf("did not received expected number of errors\n\t\twant:\t1 error\n\t\tgot:\t%+v", got.Errs)
 					}
 
 					wantErr := fdk.APIError{Code: http.StatusNotFound, Message: "route not found"}
-					equalVals(t, wantErr, got.Errs[0])
+					fdk.EqualVals(t, wantErr, got.Errs[0])
 				},
 			},
 			{
@@ -402,15 +402,15 @@ integer: 1`,
 					return m
 				},
 				want: func(t *testing.T, resp *http.Response, got respBody) {
-					equalVals(t, 405, resp.StatusCode)
-					equalVals(t, 405, got.Code)
+					fdk.EqualVals(t, 405, resp.StatusCode)
+					fdk.EqualVals(t, 405, got.Code)
 
 					if len(got.Errs) != 1 {
 						t.Fatalf("did not received expected number of errors\n\t\twant:\t1 error\n\t\tgot:\t%+v", got.Errs)
 					}
 
 					wantErr := fdk.APIError{Code: http.StatusMethodNotAllowed, Message: "method not allowed"}
-					equalVals(t, wantErr, got.Errs[0])
+					fdk.EqualVals(t, wantErr, got.Errs[0])
 				},
 			},
 			{
@@ -431,8 +431,8 @@ integer: 1`,
 					return m
 				},
 				want: func(t *testing.T, resp *http.Response, got respBody) {
-					equalVals(t, 400, resp.StatusCode)
-					equalVals(t, 400, got.Code)
+					fdk.EqualVals(t, 400, resp.StatusCode)
+					fdk.EqualVals(t, 400, got.Code)
 
 					if len(got.Errs) != 1 {
 						t.Fatalf("did not received expected number of errors\n\t\twant:\t1 error\n\t\tgot:\t%+v", got.Errs)
@@ -442,7 +442,7 @@ integer: 1`,
 						Code:    http.StatusBadRequest,
 						Message: "config is invalid: invalid config \"string\" field received: wrong string\ninvalid config \"integer\" field received: 0",
 					}
-					equalVals(t, wantErr, got.Errs[0])
+					fdk.EqualVals(t, wantErr, got.Errs[0])
 				},
 			},
 			{
@@ -464,8 +464,8 @@ integer: 1`,
 					return m
 				},
 				want: func(t *testing.T, resp *http.Response, got respBody) {
-					equalVals(t, http.StatusInternalServerError, resp.StatusCode)
-					equalVals(t, http.StatusInternalServerError, got.Code)
+					fdk.EqualVals(t, http.StatusInternalServerError, resp.StatusCode)
+					fdk.EqualVals(t, http.StatusInternalServerError, got.Code)
 
 					if len(got.Errs) != 1 {
 						t.Fatalf("did not received expected number of errors\n\t\twant:\t1 error\n\t\tgot:\t%+v", got.Errs)
@@ -475,7 +475,7 @@ integer: 1`,
 						Code:    http.StatusInternalServerError,
 						Message: "gots the error",
 					}
-					equalVals(t, wantErr, got.Errs[0])
+					fdk.EqualVals(t, wantErr, got.Errs[0])
 				},
 			},
 			{
@@ -494,8 +494,8 @@ integer: 1`,
 					)
 				},
 				want: func(t *testing.T, resp *http.Response, got respBody) {
-					equalVals(t, 501, resp.StatusCode)
-					equalVals(t, 501, got.Code)
+					fdk.EqualVals(t, 501, resp.StatusCode)
+					fdk.EqualVals(t, 501, got.Code)
 
 					if len(got.Errs) != 3 {
 						t.Fatalf("did not received expected number of errors\n\t\twant:\t3 error\n\t\tgot:\t%+v", got.Errs)
@@ -506,9 +506,9 @@ integer: 1`,
 						{Code: 501, Message: "even higher"},
 						{Code: 400, Message: "some user error"},
 					}
-					equalVals(t, len(wantErrs), len(got.Errs))
+					fdk.EqualVals(t, len(wantErrs), len(got.Errs))
 					for i, want := range wantErrs {
-						equalVals(t, want, got.Errs[i])
+						fdk.EqualVals(t, want, got.Errs[i])
 					}
 				},
 			},
@@ -607,8 +607,8 @@ integer: 1`,
 					return m
 				},
 				want: func(t *testing.T, resp *http.Response, code int, workflowCtx fdk.WorkflowCtx, errs []fdk.APIError) {
-					equalVals(t, 202, resp.StatusCode)
-					equalVals(t, 202, code)
+					fdk.EqualVals(t, 202, resp.StatusCode)
+					fdk.EqualVals(t, 202, code)
 
 					if len(errs) > 0 {
 						t.Errorf("received unexpected errors\n\t\tgot:\t%+v", errs)
@@ -640,8 +640,8 @@ integer: 1`,
 					return m
 				},
 				want: func(t *testing.T, resp *http.Response, code int, workflowCtx fdk.WorkflowCtx, errs []fdk.APIError) {
-					equalVals(t, 202, resp.StatusCode)
-					equalVals(t, 202, code)
+					fdk.EqualVals(t, 202, resp.StatusCode)
+					fdk.EqualVals(t, 202, code)
 
 					if len(errs) > 0 {
 						t.Errorf("received unexpected errors\n\t\tgot:\t%+v", errs)
@@ -738,13 +738,13 @@ integer: 1`,
 					return m
 				},
 				want: func(t *testing.T, resp *http.Response, got fdk.File) {
-					equalVals(t, 201, resp.StatusCode)
+					fdk.EqualVals(t, 201, resp.StatusCode)
 
-					equalVals(t, "application/json", got.ContentType)
-					equalVals(t, "", got.Encoding)
+					fdk.EqualVals(t, "application/json", got.ContentType)
+					fdk.EqualVals(t, "", got.Encoding)
 
 					wantFilename := filepath.Join(tmp, "first_file.json")
-					equalVals(t, wantFilename, got.Filename)
+					fdk.EqualVals(t, wantFilename, got.Filename)
 					equalFiles(t, got.Filename, `{"some":"json"}`)
 				},
 			},
@@ -768,13 +768,13 @@ integer: 1`,
 					return m
 				},
 				want: func(t *testing.T, resp *http.Response, got fdk.File) {
-					equalVals(t, 201, resp.StatusCode)
+					fdk.EqualVals(t, 201, resp.StatusCode)
 
-					equalVals(t, "application/json", got.ContentType)
-					equalVals(t, "gzip", got.Encoding)
+					fdk.EqualVals(t, "application/json", got.ContentType)
+					fdk.EqualVals(t, "gzip", got.Encoding)
 
 					wantFilename := filepath.Join(tmp, "second_file.json")
-					equalVals(t, wantFilename, got.Filename)
+					fdk.EqualVals(t, wantFilename, got.Filename)
 					equalFiles(t, got.Filename, `{"dodgers":"stink"}`)
 				},
 			},
@@ -795,13 +795,13 @@ integer: 1`,
 					return m
 				},
 				want: func(t *testing.T, resp *http.Response, got fdk.File) {
-					equalVals(t, 201, resp.StatusCode)
+					fdk.EqualVals(t, 201, resp.StatusCode)
 
-					equalVals(t, "application/json", got.ContentType)
-					equalVals(t, "gzip", got.Encoding)
+					fdk.EqualVals(t, "application/json", got.ContentType)
+					fdk.EqualVals(t, "gzip", got.Encoding)
 
 					wantFilename := filepath.Join(tmp, "third_file.json")
-					equalVals(t, wantFilename, got.Filename)
+					fdk.EqualVals(t, wantFilename, got.Filename)
 					equalGzipFiles(t, got.Filename, `{"dodgers":"reallystank"}`)
 				},
 			},
@@ -972,16 +972,6 @@ func newGzippedFileHandler(_ context.Context, r fdk.RequestOf[fileInReq]) fdk.Re
 	}
 }
 
-func equalVals[T comparable](t testing.TB, want, got T) bool {
-	t.Helper()
-
-	match := want == got
-	if !match {
-		t.Errorf("values not equal:\n\t\twant:\t%#v\n\t\tgot:\t%#v", want, got)
-	}
-	return match
-}
-
 func equalFiles(t testing.TB, filename string, want string) {
 	t.Helper()
 
@@ -1016,7 +1006,7 @@ func equalReader(t testing.TB, want string, got io.Reader) {
 	b, err := io.ReadAll(got)
 	mustNoErr(t, err)
 
-	equalVals(t, want, string(b))
+	fdk.EqualVals(t, want, string(b))
 }
 
 func mustNoErr(t testing.TB, err error) {

--- a/sdk_test.go
+++ b/sdk_test.go
@@ -30,8 +30,8 @@ func TestFn(t *testing.T) {
 				fnVersion: "1",
 			},
 			wants: func(t *testing.T, gotFnID string, gotVersion int) {
-				equalVals(t, "fn-id", gotFnID)
-				equalVals(t, 1, gotVersion)
+				fdk.EqualVals(t, "fn-id", gotFnID)
+				fdk.EqualVals(t, 1, gotVersion)
 			},
 		},
 		{
@@ -41,8 +41,8 @@ func TestFn(t *testing.T) {
 				fnVersion: "",
 			},
 			wants: func(t *testing.T, gotFnID string, gotVersion int) {
-				equalVals(t, "fn-id", gotFnID)
-				equalVals(t, 0, gotVersion)
+				fdk.EqualVals(t, "fn-id", gotFnID)
+				fdk.EqualVals(t, 0, gotVersion)
 			},
 		},
 	}
@@ -67,6 +67,6 @@ func TestAPIError(t *testing.T) {
 	}
 	for _, err := range errs {
 		want := fmt.Sprintf("[%d] %s", err.Code, err.Message)
-		equalVals(t, want, err.Error())
+		fdk.EqualVals(t, want, err.Error())
 	}
 }


### PR DESCRIPTION
wanted to have files normalized in the sdk for maximum visibility into how these file names are created. Being able to point at source code here would be the most visible. It also allows us to wire up the http runner to make use of it. All runners should make use of the same normalization