### PR TITLE
fix: drop Fn Version from Fn output

### DIFF
--- a/sdk.go
+++ b/sdk.go
@@ -9,21 +9,16 @@ import (
 	"net/url"
 	"os"
 	"runtime/debug"
-	"strconv"
 )
 
 // Fn returns the active function id and version.
 func Fn() struct {
-	ID      string
-	Version int
+	ID string
 } {
-	v, _ := strconv.Atoi(os.Getenv("CS_FN_VERSION"))
 	return struct {
-		ID      string
-		Version int
+		ID string
 	}{
-		ID:      os.Getenv("CS_FN_ID"),
-		Version: v,
+		ID: os.Getenv("CS_FN_ID"),
 	}
 }
 

--- a/sdk_test.go
+++ b/sdk_test.go
@@ -11,11 +11,10 @@ import (
 func TestFn(t *testing.T) {
 	type (
 		inputs struct {
-			fnID      string
-			fnVersion string
+			fnID string
 		}
 
-		wantFn func(t *testing.T, gotFnID string, gotVersion int)
+		wantFn func(t *testing.T, gotFnID string)
 	)
 
 	tests := []struct {
@@ -26,23 +25,19 @@ func TestFn(t *testing.T) {
 		{
 			name: "fn-id set with version 1",
 			inputs: inputs{
-				fnID:      "fn-id",
-				fnVersion: "1",
+				fnID: "fn-id",
 			},
-			wants: func(t *testing.T, gotFnID string, gotVersion int) {
+			wants: func(t *testing.T, gotFnID string) {
 				fdk.EqualVals(t, "fn-id", gotFnID)
-				fdk.EqualVals(t, 1, gotVersion)
 			},
 		},
 		{
 			name: "fn-id set without version",
 			inputs: inputs{
-				fnID:      "fn-id",
-				fnVersion: "",
+				fnID: "fn-id",
 			},
-			wants: func(t *testing.T, gotFnID string, gotVersion int) {
+			wants: func(t *testing.T, gotFnID string) {
 				fdk.EqualVals(t, "fn-id", gotFnID)
-				fdk.EqualVals(t, 0, gotVersion)
 			},
 		},
 	}
@@ -50,10 +45,9 @@ func TestFn(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv("CS_FN_ID", tt.inputs.fnID)
-			t.Setenv("CS_FN_VERSION", tt.inputs.fnVersion)
 
 			fn := fdk.Fn()
-			tt.wants(t, fn.ID, fn.Version)
+			tt.wants(t, fn.ID)
 		})
 	}
 


### PR DESCRIPTION
this can create some issues with startup sequencing. Ideallly, the user is not concerning themselves with the fn version in any way. We can mostly eliminate that. At the moment, we have no ask for such a thing. Lets rip it out for now then add it back when there is an ask.

Its likely better off as a request input rather than an env var. There's no guarantee a fn version creates a separate lambda deploy. By adding it to the request, we eliminate that confusion altogether.