### PR TITLE
feat: update Request to take stream instead of json.RawMessage

### DIFF
--- a/examples/fn_config/main.go
+++ b/examples/fn_config/main.go
@@ -25,13 +25,6 @@ func newHandler(_ context.Context, cfg config) fdk.Handler {
 			Header: http.Header{"X-Fn-Method": []string{r.Method}},
 		}
 	}))
-	mux.Post("/foo", fdk.HandlerFn(func(ctx context.Context, r fdk.Request) fdk.Response {
-		return fdk.Response{
-			Body:   r.Body,
-			Code:   201,
-			Header: http.Header{"X-Fn-Method": []string{r.Method}},
-		}
-	}))
 	return mux
 }
 

--- a/fdktest/sdk.go
+++ b/fdktest/sdk.go
@@ -1,9 +1,11 @@
 package fdktest
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/xeipuuv/gojsonschema"
@@ -37,7 +39,7 @@ func HandlerSchemaOK(h fdk.Handler, r fdk.Request, reqSchema, respSchema string)
 			return fmt.Errorf("failed to marshal response payload: %w", err)
 		}
 
-		err = validateSchema(respSchema, b)
+		err = validateSchema(respSchema, bytes.NewReader(b))
 		if err != nil {
 			return fmt.Errorf("failed response schema validation: %w", err)
 		}
@@ -46,7 +48,8 @@ func HandlerSchemaOK(h fdk.Handler, r fdk.Request, reqSchema, respSchema string)
 	return nil
 }
 
-func validateSchema(schema string, payload []byte) error {
+func validateSchema(schema string, body io.Reader) error {
+	payload, _ := io.ReadAll(body)
 	result, err := gojsonschema.Validate(
 		gojsonschema.NewStringLoader(schema),
 		gojsonschema.NewBytesLoader(payload),

--- a/fdktest/sdk_test.go
+++ b/fdktest/sdk_test.go
@@ -1,6 +1,7 @@
 package fdktest_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -37,7 +38,7 @@ func TestHandlerSchemaOK(t *testing.T) {
 				req: fdk.Request{
 					URL:    "/",
 					Method: http.MethodPost,
-					Body:   json.RawMessage(`{"postalCode": "55755"}`),
+					Body:   bytes.NewReader(json.RawMessage(`{"postalCode": "55755"}`)),
 				},
 				reqSchema: `{
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -83,7 +84,7 @@ func TestHandlerSchemaOK(t *testing.T) {
 				req: fdk.Request{
 					URL:    "/",
 					Method: http.MethodPost,
-					Body:   json.RawMessage(`{"postalCode": "5"}`),
+					Body:   bytes.NewReader(json.RawMessage(`{"postalCode": "5"}`)),
 				},
 				reqSchema: `{
   "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/handler_fns.go
+++ b/handler_fns.go
@@ -20,7 +20,7 @@ func (h HandlerFn) Handle(ctx context.Context, r Request) Response {
 func HandleFnOf[T any](fn func(context.Context, RequestOf[T]) Response) Handler {
 	return HandlerFn(func(ctx context.Context, r Request) Response {
 		var v T
-		if err := json.Unmarshal(r.Body, &v); err != nil {
+		if err := json.NewDecoder(r.Body).Decode(&v); err != nil {
 			return Response{Errors: []APIError{{Code: http.StatusBadRequest, Message: "failed to unmarshal payload: " + err.Error()}}}
 		}
 

--- a/request.go
+++ b/request.go
@@ -2,14 +2,15 @@ package fdk
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/url"
 )
 
 type (
 	// Request defines a request structure that is given to the runner. The Body is set to
-	// json.RawMessage, to enable decoration/middleware.
-	Request RequestOf[json.RawMessage]
+	// io.Reader, to enable decoration/middleware.
+	Request RequestOf[io.Reader]
 
 	// RequestOf provides a generic body we can target our unmarshaling into.
 	RequestOf[T any] struct {

--- a/runner_test.go
+++ b/runner_test.go
@@ -1108,18 +1108,20 @@ func newJSONBodyHandler(cfg config) fdk.Handler {
 			Message: "gots the error",
 		})
 	}
-	return fdk.HandleFnOf(func(ctx context.Context, r fdk.RequestOf[json.RawMessage]) fdk.Response {
-		return newEchoResp(ctx, cfg, fdk.Request(r))
+	return fdk.HandlerFn(func(ctx context.Context, r fdk.Request) fdk.Response {
+		return newEchoResp(ctx, cfg, r)
 	})
 }
 
 func newEchoResp(ctx context.Context, cfg config, r fdk.Request) fdk.Response {
 	traceID, _ := ctx.Value("_traceid").(string)
+	bodyB, _ := io.ReadAll(r.Body)
 	return fdk.Response{
+
 		Body: fdk.JSON(echoReq{
 			Config: cfg,
 			Req: echoInputs{
-				Body:        r.Body,
+				Body:        bodyB,
 				Context:     r.Context,
 				Headers:     r.Params.Header,
 				Queries:     r.Params.Query,

--- a/sdk_test.go
+++ b/sdk_test.go
@@ -1,6 +1,7 @@
 package fdk_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -36,7 +37,7 @@ func TestHandlerFnOfOK(t *testing.T) {
 	})
 	mustNoErr(t, err)
 
-	resp := h.Handle(context.TODO(), fdk.Request{Body: b})
+	resp := h.Handle(context.TODO(), fdk.Request{Body: bytes.NewReader(b)})
 	fdk.EqualVals(t, http.StatusInternalServerError, resp.Code)
 
 	wantErrs := []fdk.APIError{


### PR DESCRIPTION
this enables us to support a streaming API :yaaaas:. With this we can enable our entire system to work with a streamed input. Locally, that means working with a multipart/form body file and the meta field.