### PR TITLE
Support for files as input to function handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,12 @@ func (c config) OK() error {
 
 more examples can be found at:
 
-- [fn with config](examples/fn_config)
-- [fn without config](examples/fn_no_config)
-- [more complex/complete example](examples/complex)
+- [Function with config](examples/fn_config)
+- [Function without config](examples/fn_no_config)
+- [More complex/complete example](examples/complex)
+- [Function with file as input](examples/single_file_input)
+- [Function with multiple files as input](examples/multiple_file_input)
+- [Function with mixed input (file(s) and JSON input)](examples/complex_inputs)
 
 ### Testing locally
 

--- a/complex_payload.go
+++ b/complex_payload.go
@@ -1,0 +1,47 @@
+package fdk
+
+import (
+	"errors"
+	"fmt"
+	"io"
+)
+
+// ComplexPayload holds a mix of file streams and general inputs to a function.
+type ComplexPayload struct {
+	// Body holds the raw version of any non-file input.
+	Body []byte
+	// Files maps the file name to the file stream.
+	Files map[string]io.Reader
+}
+
+var _ io.ReadCloser = (*ComplexPayload)(nil)
+
+// Read is unsupported. ComplexPayload should be treated as a struct.
+// This method is only added as a means to satisfy the Request type.
+func (c *ComplexPayload) Read([]byte) (int, error) {
+	return 0, errors.New("method Read() not supported - treat object as a standard struct")
+}
+
+// Close invokes Close() on all of the internal io.Closers.
+func (c *ComplexPayload) Close() error {
+	if len(c.Files) == 0 {
+		return nil
+	}
+
+	var errs error
+
+	for k, v := range c.Files {
+		if v == nil {
+			continue
+		}
+		vc, ok := v.(io.Closer)
+		if !ok {
+			continue
+		}
+		if err := vc.Close(); err != nil {
+			errs = errors.Join(errs, fmt.Errorf("failed to close %s: %w", k, err))
+		}
+	}
+
+	return errs
+}

--- a/complex_payload.go
+++ b/complex_payload.go
@@ -28,7 +28,7 @@ func (c *ComplexPayload) Close() error {
 		return nil
 	}
 
-	var errs error
+	var errs []error
 
 	for k, v := range c.Files {
 		if v == nil {
@@ -39,9 +39,9 @@ func (c *ComplexPayload) Close() error {
 			continue
 		}
 		if err := vc.Close(); err != nil {
-			errs = errors.Join(errs, fmt.Errorf("failed to close %s: %w", k, err))
+			errs = append(errs, fmt.Errorf("failed to close %s: %w", k, err))
 		}
 	}
 
-	return errs
+	return errors.Join(errs...)
 }

--- a/examples/complex_inputs/lorem-ipsum-1.txt
+++ b/examples/complex_inputs/lorem-ipsum-1.txt
@@ -1,0 +1,1 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.

--- a/examples/complex_inputs/lorem-ipsum-2.txt
+++ b/examples/complex_inputs/lorem-ipsum-2.txt
@@ -1,0 +1,1 @@
+Nam facilisis condimentum tellus, quis pharetra erat dignissim vel.

--- a/examples/complex_inputs/lorem-ipsum-3.txt
+++ b/examples/complex_inputs/lorem-ipsum-3.txt
@@ -1,0 +1,1 @@
+Donec ullamcorper diam nec commodo laoreet.

--- a/examples/complex_inputs/main.go
+++ b/examples/complex_inputs/main.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	fdk "github.com/CrowdStrike/foundry-fn-go"
+)
+
+func main() {
+	fdk.Run(context.Background(), newHandler)
+}
+
+// newHandler showcases how to provide multiple inputs to a function, some of which happen to be files.
+// In this case, it simply echoes back the contents of those files concatenated together with spaces.
+// This could easily be changed to something more advanced to work with arbitrary binary.
+func newHandler(_ context.Context, log *slog.Logger, _ fdk.SkipCfg) fdk.Handler {
+	mux := fdk.NewMux()
+	mux.Post("/my-endpoint", fdk.HandlerFn(func(ctx context.Context, r fdk.Request) fdk.Response {
+		s, greeting, err := readInputs(r.Body)
+		if err != nil {
+			log.With("error", err).Error("failed to read payload")
+			return fdk.ErrResp(fdk.APIError{
+				Code:    500,
+				Message: fmt.Sprintf("failed to read payload with error: %s", err),
+			})
+		}
+		return fdk.Response{
+			Body: fdk.JSON(map[string]string{
+				"allText":  s,
+				"greeting": greeting,
+			}),
+			Code:   200,
+			Header: http.Header{"X-Fn-Method": []string{r.Method}},
+		}
+	}))
+	return mux
+}
+
+type personInfo struct {
+	Name string `json:"name"`
+	Age  int    `json:"age"`
+}
+
+func readInputs(body io.Reader) (string, string, error) {
+	if c, ok := body.(*fdk.ComplexPayload); ok {
+		// Multiple files are presented in a map of string -> io.Reader.
+		// This mapping consists of the filename and a link to the uploaded file.
+		contents := make([]string, 0)
+		for _, r := range c.Files {
+			s, err := readString(r)
+			if err != nil {
+				return "", "", err
+			}
+			contents = append(contents, s)
+		}
+
+		// The person's name and age are in a JSON string.
+		var p personInfo
+		if err := json.Unmarshal(c.Body, &p); err != nil {
+			return "", "", err
+		}
+		greeting := fmt.Sprintf("Welcome %s, age %d", p.Name, p.Age)
+
+		return strings.Join(contents, " "), greeting, nil
+	}
+
+	s, err := readString(body)
+	return s, "", err
+}
+
+func readString(r io.Reader) (string, error) {
+	b, err := io.ReadAll(r)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}

--- a/examples/complex_inputs/test.sh
+++ b/examples/complex_inputs/test.sh
@@ -1,0 +1,13 @@
+curl -X POST --location "http://localhost:8081" \
+    -H "Content-Type: multipart/form-data" \
+    -F meta='{
+          "url": "/my-endpoint",
+          "method": "POST"
+      }' \
+    -F body='{
+           "name": "Sam",
+           "age": 35
+       }' \
+    -F file1='@lorem-ipsum-1.txt;filename=lorem-ipsum-1.txt' \
+    -F file2='@lorem-ipsum-2.txt;filename=lorem-ipsum-2.txt' \
+    -F file3='@lorem-ipsum-3.txt;filename=lorem-ipsum-3.txt'

--- a/examples/multiple_file_input/lorem-ipsum-1.txt
+++ b/examples/multiple_file_input/lorem-ipsum-1.txt
@@ -1,0 +1,1 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.

--- a/examples/multiple_file_input/lorem-ipsum-2.txt
+++ b/examples/multiple_file_input/lorem-ipsum-2.txt
@@ -1,0 +1,1 @@
+Nam facilisis condimentum tellus, quis pharetra erat dignissim vel.

--- a/examples/multiple_file_input/lorem-ipsum-3.txt
+++ b/examples/multiple_file_input/lorem-ipsum-3.txt
@@ -1,0 +1,1 @@
+Donec ullamcorper diam nec commodo laoreet.

--- a/examples/multiple_file_input/main.go
+++ b/examples/multiple_file_input/main.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	fdk "github.com/CrowdStrike/foundry-fn-go"
+)
+
+func main() {
+	fdk.Run(context.Background(), newHandler)
+}
+
+// newHandler showcases how to provide multiple inputs to a function which happen to be files.
+// In this case, it simply echoes back the contents of those files concatenated together with spaces.
+// This could easily be changed to something more advanced to work with arbitrary binary.
+func newHandler(_ context.Context, log *slog.Logger, _ fdk.SkipCfg) fdk.Handler {
+	mux := fdk.NewMux()
+	mux.Post("/my-endpoint", fdk.HandlerFn(func(ctx context.Context, r fdk.Request) fdk.Response {
+		s, err := readFiles(r.Body)
+		if err != nil {
+			log.With("error", err).Error("failed to read payload")
+			return fdk.ErrResp(fdk.APIError{
+				Code:    500,
+				Message: fmt.Sprintf("failed to read payload with error: %s", err),
+			})
+		}
+		return fdk.Response{
+			Body:   fdk.JSON(map[string]string{"allText": s}),
+			Code:   200,
+			Header: http.Header{"X-Fn-Method": []string{r.Method}},
+		}
+	}))
+	return mux
+}
+
+func readFiles(body io.Reader) (string, error) {
+	if c, ok := body.(*fdk.ComplexPayload); ok {
+		// Multiple files are presented in a map of string -> io.Reader.
+		// This mapping consists of the filename and a link to the uploaded file.
+		contents := make([]string, 0)
+		for _, r := range c.Files {
+			s, err := readString(r)
+			if err != nil {
+				return "", err
+			}
+			contents = append(contents, s)
+		}
+		return strings.Join(contents, " "), nil
+	}
+
+	return readString(body)
+}
+
+func readString(r io.Reader) (string, error) {
+	b, err := io.ReadAll(r)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}

--- a/examples/multiple_file_input/test.sh
+++ b/examples/multiple_file_input/test.sh
@@ -1,0 +1,9 @@
+curl -X POST --location "http://localhost:8081" \
+    -H "Content-Type: multipart/form-data" \
+    -F meta='{
+  "url": "/my-endpoint",
+  "method": "POST"
+}' \
+    -F body1='@lorem-ipsum-1.txt;filename=lorem-ipsum-1.txt' \
+    -F body2='@lorem-ipsum-2.txt;filename=lorem-ipsum-2.txt' \
+    -F body3='@lorem-ipsum-3.txt;filename=lorem-ipsum-3.txt'

--- a/examples/single_file_input/lorem-ipsum.txt
+++ b/examples/single_file_input/lorem-ipsum.txt
@@ -1,0 +1,1 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.

--- a/examples/single_file_input/main.go
+++ b/examples/single_file_input/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+
+	fdk "github.com/CrowdStrike/foundry-fn-go"
+)
+
+func main() {
+	fdk.Run(context.Background(), newHandler)
+}
+
+// newHandler showcases how to provide a single input to a function which happens to be a file.
+// In this case, it simply echos back the contents of a text file, though this could easily
+// be changed to do something more advanced or to work with arbitrary binary data.
+func newHandler(_ context.Context, log *slog.Logger, _ fdk.SkipCfg) fdk.Handler {
+	mux := fdk.NewMux()
+	mux.Post("/my-endpoint", fdk.HandlerFn(func(ctx context.Context, r fdk.Request) fdk.Response {
+		b, err := io.ReadAll(r.Body)
+		if err != nil {
+			log.With("error", err).Error("failed to read payload")
+			return fdk.ErrResp(fdk.APIError{
+				Code:    500,
+				Message: fmt.Sprintf("failed to read payload with error: %s", err),
+			})
+		}
+
+		return fdk.Response{
+			Body:   fdk.JSON(map[string]string{"fileContents": string(b)}),
+			Code:   200,
+			Header: http.Header{"X-Fn-Method": []string{r.Method}},
+		}
+	}))
+	return mux
+}

--- a/examples/single_file_input/test.sh
+++ b/examples/single_file_input/test.sh
@@ -1,0 +1,8 @@
+curl -X POST --location "http://localhost:8081" \
+    -H "Accept: application/json" \
+    -H "Content-Type: multipart/form-data" \
+    -F meta='{
+  "url": "/my-endpoint",
+  "method": "POST"
+}' \
+    -F body='@lorem-ipsum.txt;filename=lorem-ipsum.txt'

--- a/runner_http.go
+++ b/runner_http.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"mime/multipart"
 	"net/http"
 	"net/url"
 	"os"
@@ -69,6 +70,14 @@ func dispatchReq(logger *slog.Logger, handler Handler) http.Handler {
 
 		r, closeFn, err := toRequest(req)
 		if err != nil {
+			defer func() {
+				if closeFn == nil {
+					return
+				}
+				if err := closeFn(); err != nil {
+					logger.Error("failed to close request body", "err", err.Error())
+				}
+			}()
 			logger.Error("failed to create request", "err", err)
 			writeErr := writeResponse(logger, w, ErrResp(APIError{Code: http.StatusInternalServerError, Message: "unable to process incoming request"}))
 			if writeErr != nil {
@@ -188,12 +197,48 @@ func fromMultipartReq(req *http.Request) (reqMeta, io.ReadCloser, error) {
 		return reqMeta{}, nil, fmt.Errorf("failed to json unmarshal meta from multipart field: %w", err)
 	}
 
+	mpf := req.MultipartForm
+	if isComplexMultipartReq(mpf) {
+		return fromComplexMultipartReq(reqFn, mpf)
+	}
+
 	body, _, err := req.FormFile("body")
 	if err != nil {
 		return reqMeta{}, nil, fmt.Errorf("failed to read multipart body form file: %w", err)
 	}
 
 	return reqFn, body, nil
+}
+
+func isComplexMultipartReq(m *multipart.Form) bool {
+	f, v := m.File, m.Value
+	// Multiple files or (at least one file and a value other than "meta").
+	return len(f) > 1 || (len(f) >= 1 && len(v) > 1)
+}
+
+func fromComplexMultipartReq(reqFn reqMeta, m *multipart.Form) (reqMeta, *ComplexPayload, error) {
+	c := &ComplexPayload{
+		Body:  nil,
+		Files: make(map[string]io.Reader),
+	}
+
+	if b, ok := m.Value["body"]; ok {
+		if len(b) > 0 {
+			c.Body = []byte(b[0])
+		}
+	}
+
+	for _, f := range m.File {
+		for _, header := range f {
+			f0, err := header.Open()
+			if err != nil {
+				return reqMeta{}, c, fmt.Errorf("failed to read multipart body form file %s: %w", header.Filename, err)
+			}
+			c.Files[header.Filename] = f0
+		}
+	}
+
+	return reqFn, c, nil
 }
 
 func fromJSONReq(req *http.Request) (reqMeta, io.ReadCloser, error) {

--- a/testdata/lorem-ipsum-1.txt
+++ b/testdata/lorem-ipsum-1.txt
@@ -1,0 +1,1 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.

--- a/testdata/lorem-ipsum-2.txt
+++ b/testdata/lorem-ipsum-2.txt
@@ -1,0 +1,1 @@
+Nam facilisis condimentum tellus, quis pharetra erat dignissim vel.

--- a/testdata/lorem-ipsum-3.txt
+++ b/testdata/lorem-ipsum-3.txt
@@ -1,0 +1,1 @@
+Donec ullamcorper diam nec commodo laoreet.


### PR DESCRIPTION
Addresses the need to allow functions to accept files and mixed type inputs as inbound requests.  This change allows for the following:

- Allows for requests of a single file to be accepted by a function.
- Allows for requests of multiple inbound files to be accepted by a function.
- Allows for requests of mixed input types (file(s) and JSON) to be accepted as input by a function.

Two new examples are included showcasing how to use the input types.