### PR TITLE
HTTP response Content-Type set to application/json

### DIFF
--- a/runner_http.go
+++ b/runner_http.go
@@ -278,6 +278,7 @@ func writeResponse(logger *slog.Logger, w http.ResponseWriter, resp Response) er
 		return nil
 	}
 
+	w.Header().Set("Content-Type", "application/json")
 	if code := resp.StatusCode(); code != 0 {
 		w.WriteHeader(code)
 	}


### PR DESCRIPTION
In order to align with the foundry-fn-python, the HTTP response has its content-type set to application/json.